### PR TITLE
docs(*): quickstart and helm chart-related updates

### DIFF
--- a/charts/spin-operator/Chart.yaml
+++ b/charts/spin-operator/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "v0.1.0"
 
 dependencies:
   - name: kwasm-operator

--- a/charts/spin-operator/README.md
+++ b/charts/spin-operator/README.md
@@ -15,21 +15,15 @@ Prior to installing the chart, you'll need to ensure the following:
   <!-- TODO: templatize with release version corresponding to chart's appVersion -->
 
   ```console
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
   ```
 
 - A RuntimeClass resource for the `wasmtime-spin-v2` container runtime is installed. This is the runtime that Spin applications use.
 
-  <!-- TODO: point to GH release artifact and templatize with release version corresponding to chart's appVersion? Or static code link? -->
+  <!-- TODO: templatize with release version corresponding to chart's appVersion -->
 
   ```console
-  $ kubectl apply -f - <<EOF
-  apiVersion: node.k8s.io/v1
-  kind: RuntimeClass
-  metadata:
-    name: wasmtime-spin-v2
-  handler: spin
-  EOF
+  kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml
   ```
 
 ## Chart dependencies
@@ -51,15 +45,17 @@ The following installs the chart with the release name `spin-operator`:
 <!-- TODO: templatize with release version corresponding to chart's appVersion -->
 
 ```console
-$ helm install spin-operator --namespace spin-operator oci://ghcr.io/spinkube/spin-operator
+$ helm install spin-operator --namespace spin-operator --create-namespace oci://ghcr.io/spinkube/spin-operator
 ```
 
 ## Upgrading the chart
 
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
+<!-- TODO: templatize with release version corresponding to chart's appVersion -->
+
 ```console
-$ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+$ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
 ```
 
 To upgrade the `spin-operator` release, run the following:
@@ -80,10 +76,12 @@ This will remove all Kubernetes resources associated with the chart and deletes 
 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
-```console
-$ kubectl delete -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+<!-- TODO: templatize with release version corresponding to chart's appVersion -->
 
-$ kubectl delete runtimeclass wasmtime-spin-v2
+```console
+$ kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
+
+$ kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/charts/spin-operator/templates/NOTES.txt
+++ b/charts/spin-operator/templates/NOTES.txt
@@ -12,19 +12,11 @@ Kubernetes cluster before it can run the first Spin application.
 
 1. Install the spin-operator CustomResourceDefinition (CRD) resources:
 
-  {{ if eq .Values.controllerManager.manager.image.tag "latest" }}
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
-  {{ else }}
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v{{ .Chart.AppVersion }}/spin-operator.crds.yaml
-  {{ end }}
+  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/{{ .Chart.AppVersion }}/spin-operator.crds.yaml
 
 2. Install the wasmtime-spin-v2 RuntimeClass:
 
-  {{ if eq .Values.controllerManager.manager.image.tag "latest" }}
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.runtime-class.yaml
-  {{ else }}
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v{{ .Chart.AppVersion }}/spin-operator.runtime-class.yaml
-  {{ end }}
+  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/{{ .Chart.AppVersion }}/spin-operator.runtime-class.yaml
 
 3. Finally, install the containerd wasm shim on at least one node. This shim is
 necessary for running Spin application workloads. We use the Kwasm Operator

--- a/documentation/content/deploying-with-helm.md
+++ b/documentation/content/deploying-with-helm.md
@@ -13,6 +13,20 @@
 
 Please ensure that your system has all of the [./prerequisites.md](prerequisites) installed before continuing.
 
+For this guide in particular, you will need:
+
+- [kubectl](./prerequisites.md#kubectl) - the Kubernetes CLI
+- [Helm](./prerequisites.md#helm) - the package manager for Kubernetes
+
+<!-- NOTE: remove this prerequisite when the runtime-class and CRDs can be applied from their release artifacts, i.e. when repo and release are public -->
+
+Also, ensure you have cloned this repository and have navigated to the root of the project:
+
+```shell
+git clone git@github.com:spinkube/spin-operator.git
+cd spin-operator
+```
+
 ## Install Spin Operator Using Helm
 
 The following instructions are for installing Spin Operator as a chart (using helm install).
@@ -23,24 +37,18 @@ Before installing the chart, you'll need to ensure the following:
 
 The [Custom Resource Definition (CRD)](glossary-of-terms#custom-resource-definition-crd) resources are installed. This includes the SpinApp CRD representing Spin applications to be scheduled on the cluster.
 
-<!-- TODO: templatize with release version corresponding to chart -->
+<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
 
-```console
-$ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+```shell
+make install
 ```
 
 A [RuntimeClass](glossary-of-terms/#runtime-class) resource for the `wasmtime-spin-v2` container runtime is installed. This is the runtime that Spin applications use.
 
-<!-- TODO: point to GH release artifact and templatize with release version corresponding to chart? Or static code link? -->
+<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
 
-```console
-$ kubectl apply -f - <<EOF
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: wasmtime-spin-v2
-handler: spin
-EOF
+```shell
+kubectl apply -f spin-runtime-class.yaml
 ```
 
 ## Chart dependencies
@@ -59,42 +67,62 @@ The spin-operator chart currently includes the following sub-charts:
 
 The following installs the chart with the release name `spin-operator`:
 
-<!-- TODO: templatize with release version corresponding to chart -->
+<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
 
-```console
-$ helm install spin-operator --namespace spin-operator oci://ghcr.io/spinkube/spin-operator
+```shell
+helm install spin-operator \
+  --namespace spin-operator \
+  --create-namespace \
+  --devel \
+  --wait \
+  oci://ghcr.io/spinkube/spin-operator
 ```
 
 ### Upgrading the Chart
 
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
-```console
-$ kubectl apply -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
+
+```
+make install
 ```
 
 To upgrade the `spin-operator` release, run the following:
 
-```console
-$ helm upgrade spin-operator --namespace spin-operator oci://ghcr.io/spinkube/spin-operator
+<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is released and public -->
+
+```shell
+helm upgrade spin-operator \
+  --namespace spin-operator \
+  --devel \
+  --wait \
+  oci://ghcr.io/spinkube/spin-operator
 ```
 
 ### Uninstalling the Chart
 
 To delete the `spin-operator` release, run:
 
-```console
-$ helm delete spin-operator --namespace spin-operator
+```shell
+helm delete spin-operator --namespace spin-operator
 ```
 
 This will remove all Kubernetes resources associated with the chart and deletes the Helm release.
 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
-```console
-$ kubectl delete -f https://github.com/spinkube/spin-operator/releases/latest/download/spin-operator.crds.yaml
+<!-- TODO: replace with:
+```shell
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml
 
-$ kubectl delete runtimeclass wasmtime-spin-v2
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml
+```
+-->
+
+```shell
+make uninstall
+kubectl delete -f spin-runtime-class.yaml
 ```
 
 <!-- TODO: list out configuration options? -->

--- a/documentation/content/quickstart.md
+++ b/documentation/content/quickstart.md
@@ -1,36 +1,108 @@
 - [Quickstart](#quickstart)
+  - [Prerequisites](#prerequisites)
+  - [Set up your Kubernetes cluster](#set-up-your-kubernetes-cluster)
+  - [Install Spin Operator](#install-spin-operator)
+  - [Run the sample application](#run-the-sample-application)
 
 # Quickstart
 
-TODO
-Helm plus the `kubectl apply` for CRDs is recommended. Documentation coming soon.
+This Quickstart guide demonstrates how to set up a new Kubernetes cluster, install the Spin Operator and deploy your first Spin application.
 
 ## Prerequisites
 
 Ensure necessary [prerequisites](./prerequisites.md) are installed.
 
-### Setting Up Your Kubernetes Cluster
+For this Quickstart in particular, you will need:
 
-1. Create a Kubernetes k3d cluster that has containerd-wasm-shim pre-requistes installed:
+- [kubectl](./prerequisites.md#kubectl) - the Kubernetes CLI
+- [k3d](./prerequisites.md#k3d) - a lightweight Kubernetes distribution that runs on Docker
+- [Docker](./prerequisites.md#docker) - for running k3d
+- [Helm](./prerequisites.md#helm) - the package manager for Kubernetes
+
+<!-- NOTE: remove this prerequisite when the runtime-class and CRDs can be applied from their release artifacts, i.e. when repo and release are public -->
+
+Also, ensure you have cloned this repository and have navigated to the root of the project:
 
 ```
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.10.0 -p "8081:80@loadbalancer" --agents 2
+git clone git@github.com:spinkube/spin-operator.git
+cd spin-operator
 ```
 
-2. Apply the Runtime Class:
+### Set up Your Kubernetes Cluster
+
+1. Create a Kubernetes cluster with a k3d image that includes the [containerd-shim-spin](https://github.com/spinkube/containerd-shim-spin) prerequisite already installed:
+
+<!-- TODO: update below with ghcr.io/spinkube/containerd-shim-spin/examples/k3d:<tag> -->
+
+```
+k3d cluster create wasm-cluster \
+  --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.10.0 \
+  --port "8081:80@loadbalancer" \
+  --agents 2
+```
+
+> Note: Spin Operator requires a few Kubernetes resources that are installed globally to the cluster. We create these directly through `kubectl` as a best practice, since their lifetimes are usually managed separately from a given Spin Operator installation.
+
+2. Apply the [Runtime Class](../../spin-runtime-class.yaml) used for scheduling Spin apps onto nodes running the shim:
+
+<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.runtime-class.yaml' -->
 
 ```
 kubectl apply -f spin-runtime-class.yaml
 ```
 
-## Running the Sample Application
+3. Apply the [Custom Resource Definitions](./glossary-of-terms.md#custom-resource-definition-crd) used by the Spin Operator:
 
-1. `make install` to install the SpinApp CRD on to the cluster
-2. `make run` to build and run the controller locally
-3. In a different terminal window: `kubectl apply -f config/samples/shim-executor.yaml`
-4. `kubectl apply -f config/samples/simple.yaml`
-5. `kubectl port-forward svc/simple-spinapp 8083:80`
-6. In a different terminal window: `curl localhost:8083/hello`
+<!-- TODO: replace with e.g. 'kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0-rc.1/spin-operator.crds.yaml' -->
+
+```
+make install
+```
+
+## Install Spin Operator
+
+Now that your Kubernetes cluster is prepared, you can install the Spin Operator via its Helm chart:
+
+<!-- TODO: remove '--devel' flag once we have our first non-prerelease chart available, e.g. when v0.1.0 of this project is out -->
+
+```
+helm install spin-operator \
+  --namespace spin-operator \
+  --create-namespace \
+  --devel \
+  --wait \
+  oci://ghcr.io/spinkube/spin-operator
+```
+
+This will create all of the Kubernetes resources required by Spin Operator under the Kubernetes namespace `spin-operator`. It may take a moment for the installation to complete as dependencies are installed and pods are spinning up.
+
+## Run the Sample Application
+
+You are now ready to deploy Spin applications onto the cluster!
+
+<!-- TODO: if/when we have the option and if we wanted to, we could mention that the kwasm operator isn't needed when using k3d, as the containerd-shim-spin is already present. Installation could be skipped via --set kwasm-operator.enabled=false -->
+
+1. Create your first application in the same `spin-operator` namespace that the operator is running:
+
+<!-- Note: the default 'containerd-shim-spin' SpinAppExecutor CR needs to be present on the cluster before apps using this default can run. However, as of writing, it is a namespaced resource. As such, apps can only be deployed in the same namespace(s) that the CR is present. -->
+
+```
+kubectl -n spin-operator apply -f config/samples/simple.yaml
+```
+
+<!-- TODO: Use spin-k8s-plugin here? -->
+
+2. Forward a local port to the application pod so that it can be reached:
+
+```
+kubectl -n spin-operator port-forward svc/simple-spinapp 8083:80
+```
+
+3. In a different terminal window, make a request to the application:
+
+```
+curl localhost:8083/hello
+```
 
 You should see:
 
@@ -38,4 +110,4 @@ You should see:
 Hello world from Spin!
 ```
 
-If you want to test the admission webhooks you'll need to follow the instructions [here](operator_development.md) to deploy the operator to the cluster. We disable webhooks when using `make run` because that would require us to locally setup TLS certificates.
+<!-- TODO: guide the reader to the next relevant documentation section -->

--- a/documentation/content/scaling-spinapp-on-k8s-with-hpa.md
+++ b/documentation/content/scaling-spinapp-on-k8s-with-hpa.md
@@ -10,7 +10,7 @@
 # Scaling Spinapp on Kubernetes (k8s) With Horizontal Pod Autoscaling (HPA)
 
 Horizontal scaling, in the k8s sense, means deploying more pods to meet demand (different from vertical scaling whereby more memory and CPU resources are assigned to already running pods). In this tutorial, we configure [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to dynamically scale the instance count of our SpinApps to meet the demand.
-    
+
 ## Prerequisites
 
 > We use k3d to run a k8s cluster locally as part of this tutorial, but you can follow these steps to configure HPA autoscaling on your desired k8s environment.


### PR DESCRIPTION
Ref https://github.com/fermyon/spin-operator/issues/180

- Updates the Quickstart and deploying-with-helm guide as suggested in https://github.com/fermyon/spin-operator/issues/180
  - Here we've decided to temporarily instruct users to utilize a clone of the repo for kubectl apply-ing the runtime-class and CRDs.  Once the repo is public, we intend to update these steps and remove the repo clone prereq.
- Helm chart-related updates
  - Note: I've kept the chart README.md and NOTES.txt with speculative manifest urls for kubectl apply-ing the runtime-class and CRDs.
- (Change to an otherwise [unrelated file](https://github.com/spinkube/spin-operator/pull/2/files#diff-20e8e368ec06116cf030afab274dd02a7560e0ef0f3ed13e966d03c688722370) is to appease the lint check.)
