### PR TITLE
feat(chart): add containerd-shim-spin-executor.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ HELM_CHART := spin-operator
 helm-generate: manifests kustomize helmify ## Create/update the Helm chart based on kustomize manifests. (Note: CRDs not included)
 	$(KUSTOMIZE) build config/default | $(HELMIFY) -crd-dir -cert-manager-as-subchart -cert-manager-version v1.13.3 charts/$(HELM_CHART)
 	rm -rf charts/$(HELM_CHART)/crds
+	@# Copy the containerd-shim-spin SpinAppExecutor yaml from its canonical location into the chart
+	cp config/samples/shim-executor.yaml charts/$(HELM_CHART)/templates/containerd-shim-spin-executor.yaml
 	$(HELM) dep up charts/$(HELM_CHART)
 
 ##@ Deployment

--- a/charts/spin-operator/templates/containerd-shim-spin-executor.yaml
+++ b/charts/spin-operator/templates/containerd-shim-spin-executor.yaml
@@ -1,0 +1,5 @@
+apiVersion: core.spinoperator.dev/v1
+kind: SpinAppExecutor
+metadata:
+  name: containerd-shim-spin
+spec:


### PR DESCRIPTION
Add the default `containerd-shim-spin` SpinAppExecutor CR yaml to the chart

I kept this purposely simple (straight copy, no actual templating) for now.

Note: seeing behavior mentioned in https://github.com/spinkube/spin-operator/pull/7#discussion_r1476746349 involving the inability to delete this resource.  However, the same symptoms also occur when the resource is not included in the chart and I `kubectl apply` it directly prior to chart install.  I suspect the issue lies in Spin Operator and its finalizer/handling for these CRs.