### PR TITLE
ci(release): add release and chart publishing logic

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [ main ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ main ]
 
@@ -21,8 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup version info
+      - name: Setup version info - main
+        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
         run: echo "VERSION=$(date +%Y%m%d-%H%M%S)-g$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Setup version info - tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,107 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # Note: we release the chart on every release/tag in the repo, keeping the chart version
+  # and operator version (appVersion in Chart.yaml) aligned, primarily to keep things simple
+  # instead of attempting to manage asynchronous chart releases/versions.
+  publish-chart:
+    name: Package and publish chart and manifests
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.release-version.outputs.version }}
+      CHART_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Determine chart version - main
+        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+        # TODO: swap '0.0.0' with '$(git describe --tags --abbrev=0 | sed -rn 's/(v)?(.*)/\2/p')' when we have our first tag
+        run: echo "CHART_VERSION=0.0.0-$(date +%Y%m%d-%H%M%S)-g$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Determine chart version - tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        # NOTE: We remove the leading 'v' to comply with helm's versioning requirements
+        run: echo "CHART_VERSION=$(echo -n ${{ github.ref_name }} | sed -rn 's/(v)?(.*)/\2/p')" >> "$GITHUB_ENV"
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build chart
+        run: make helm-generate
+
+      - name: Package chart and manifests
+        run: make dist
+
+      - name: Lint packaged chart
+        run: |
+          # Remove staged chart directory and lint the packaged version
+          rm -rf _dist/spin-operator-${{ env.CHART_VERSION }}
+          helm lint _dist/spin-operator-${{ env.CHART_VERSION }}.tgz
+
+      - name: Upload chart and manifests as GitHub artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: spin-operator
+          path: _dist
+
+      - name: Publish chart
+        run: make helm-publish
+
+  create-gh-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: [publish-chart]
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: spin-operator
+          path: _dist
+
+      - name: check if pre-release
+        shell: bash
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]
+          then
+            echo "PRERELEASE=--prerelease" >> "$GITHUB_ENV"
+          fi
+
+      - name: create GitHub release
+        run: |
+          gh release create ${{ github.ref_name }} _dist/* \
+            --title ${{ github.ref_name }} \
+            --generate-notes ${{ env.PRERELEASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Dockerfile.cross
 # Helm chart dependencies
 
 charts/spin-operator/charts
+
+# Staging dir for packaging/releasing
+_dist

--- a/charts/spin-operator/Chart.yaml
+++ b/charts/spin-operator/Chart.yaml
@@ -13,11 +13,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+# NOTE: this version is kept static in version control but is bumped when packaging and releasing
 version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# NOTE: this version is kept static in version control but is bumped when packaging and releasing
 appVersion: "v0.1.0"
 
 dependencies:


### PR DESCRIPTION
Add release and chart publishing logic.

Current approach:
- publish an immutable eg `0.1.0-<prerelease_info>` chart on each merge to main.  Being a pre-release, it needs to either be specifically supplied as a version when installing, eg: `helm install --version 0.1.0-dev spin-operator oci://ghcr.io/spinkube/spin-operator` _or_ helm should fetch the latest pre-release (alphanumerical ordering) for an upcoming release with `helm install --devel  spin-operator oci://ghcr.io/spinkube/spin-operator` -- assuming we employ alphanumerically-orderable prerelease info.

- publish an immutable semver chart on git tags, eg when the `v0.1.0` git tag is pushed, a `v0.1.0` spin operator image will be published and a `0.1.0` helm chart will be published.  Helm will install the latest semver release by default, or a specific version can be supplied, eg:
```
helm install -n spin-operator spin-operator oci://ghcr.io/spinkube/spin-operator
# or
helm install -n spin-operator --version 0.1.0 spin-operator oci://ghcr.io/spinkube/spin-operator
```