### PR TITLE
fix helm lint by defining new template helper

### DIFF
--- a/charts/spin-operator/templates/_helpers.tpl
+++ b/charts/spin-operator/templates/_helpers.tpl
@@ -23,6 +23,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+
+{{/*
+helmify replaces namespace name with `{{ .Release.Namespace }}` in dnsNames for Certificate object
+which means `{{ include "spin-operator.fullname" . }}` gets replaced with `{{ include "{{ .Release.Namespace }}.fullname" . }}`
+
+This is most likely a bug in helmify, but we can workaround it by defining a new template helper with name `{{ .Release.Namespace }}.fullname`
+*/}}
+{{- define "{{ .Release.Namespace }}.fullname" -}}
+{{ include "spin-operator.fullname" . }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/spin-operator/templates/serving-cert.yaml
+++ b/charts/spin-operator/templates/serving-cert.yaml
@@ -9,9 +9,9 @@ metadata:
   {{- include "spin-operator.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - '{{ include "spin-operator.fullname" . }}-webhook-service.{{ .Release.Namespace
+  - '{{ include "{{ .Release.Namespace }}.fullname" . }}-webhook-service.{{ .Release.Namespace
     }}.svc'
-  - '{{ include "spin-operator.fullname" . }}-webhook-service.{{ .Release.Namespace
+  - '{{ include "{{ .Release.Namespace }}.fullname" . }}-webhook-service.{{ .Release.Namespace
     }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer


### PR DESCRIPTION
[helmify replaces release name](https://github.com/arttor/helmify/blob/909d091dd6771aee63b43a9df16c22bdc883ffb9/pkg/processor/webhook/cert.go#L68C52-L68C59) (in this case `spin-operator`) with `{{ .Release.Namespace }}` in dnsNames for Certificate object.

This means `{{ include "spin-operator.fullname" . }}` gets replaced with `{{ include "{{ .Release.Namespace }}.fullname" . }}`

This is most likely a bug in helmify, but we can workaround it by defining a new template helper with name `{{ .Release.Namespace }}.fullname`