### PR TITLE
webhooks: Validate annotations based on Executor properties

### DIFF
--- a/internal/webhook/spinapp_validating_test.go
+++ b/internal/webhook/spinapp_validating_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"errors"
 	"testing"
 
 	spinv1 "github.com/spinkube/spin-operator/api/v1"
@@ -11,13 +12,15 @@ import (
 func TestValidateExecutor(t *testing.T) {
 	t.Parallel()
 
-	fldErr := validateExecutor(spinv1.SpinAppSpec{}, func(string) bool { return true })
+	_, fldErr := validateExecutor(spinv1.SpinAppSpec{}, func(string) (*spinv1.SpinAppExecutor, error) { return nil, nil })
 	require.EqualError(t, fldErr, "spec.executor: Invalid value: \"\": executor must be set, likely no default executor was set because you have no executors installed")
 
-	fldErr = validateExecutor(spinv1.SpinAppSpec{Executor: constants.CyclotronExecutor}, func(string) bool { return false })
+	_, fldErr = validateExecutor(
+		spinv1.SpinAppSpec{Executor: constants.CyclotronExecutor},
+		func(string) (*spinv1.SpinAppExecutor, error) { return nil, errors.New("executor not found?") })
 	require.EqualError(t, fldErr, "spec.executor: Invalid value: \"cyclotron\": executor does not exist on cluster")
 
-	fldErr = validateExecutor(spinv1.SpinAppSpec{Executor: constants.ContainerDShimSpinExecutor}, func(name string) bool { return true })
+	_, fldErr = validateExecutor(spinv1.SpinAppSpec{Executor: constants.ContainerDShimSpinExecutor}, func(string) (*spinv1.SpinAppExecutor, error) { return nil, nil })
 	require.Nil(t, fldErr)
 }
 
@@ -34,30 +37,41 @@ func TestValidateReplicas(t *testing.T) {
 func TestValidateAnnotations(t *testing.T) {
 	t.Parallel()
 
+	deploymentlessExecutor := &spinv1.SpinAppExecutor{
+		Spec: spinv1.SpinAppExecutorSpec{
+			CreateDeployment: false,
+		},
+	}
+	deploymentfullExecutor := &spinv1.SpinAppExecutor{
+		Spec: spinv1.SpinAppExecutorSpec{
+			CreateDeployment: true,
+		},
+	}
+
 	fldErr := validateAnnotations(spinv1.SpinAppSpec{
-		Executor:              constants.CyclotronExecutor,
+		Executor:              "an-executor",
 		DeploymentAnnotations: map[string]string{"key": "asdf"},
-	})
+	}, deploymentlessExecutor)
 	require.EqualError(t, fldErr,
 		`spec.deploymentAnnotations: Invalid value: map[string]string{"key":"asdf"}: `+
-			`deploymentAnnotations can't be set when runtime is cyclotron`)
+			`deploymentAnnotations can't be set when the executor does not use operator deployments`)
 
 	fldErr = validateAnnotations(spinv1.SpinAppSpec{
-		Executor:       constants.CyclotronExecutor,
+		Executor:       "an-executor",
 		PodAnnotations: map[string]string{"key": "asdf"},
-	})
+	}, deploymentlessExecutor)
 	require.EqualError(t, fldErr,
 		`spec.podAnnotations: Invalid value: map[string]string{"key":"asdf"}: `+
-			`podAnnotations can't be set when runtime is cyclotron`)
+			`podAnnotations can't be set when the executor does not use operator deployments`)
 
 	fldErr = validateAnnotations(spinv1.SpinAppSpec{
-		Executor:              constants.ContainerDShimSpinExecutor,
+		Executor:              "an-executor",
 		DeploymentAnnotations: map[string]string{"key": "asdf"},
-	})
+	}, deploymentfullExecutor)
 	require.Nil(t, fldErr)
 
 	fldErr = validateAnnotations(spinv1.SpinAppSpec{
-		Executor: constants.CyclotronExecutor,
-	})
+		Executor: "an-executor",
+	}, deploymentlessExecutor)
 	require.Nil(t, fldErr)
 }


### PR DESCRIPTION
Rather than hardcoding behaviour based on the name of the executor, derive validation based on properties of the executor.