### PR TITLE
Revert "publish latest tag for container image"

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -83,4 +83,3 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ghcr.io/spinkube/spin-operator:${{ env.VERSION }}
-            ghcr.io/spinkube/spin-operator:latest


### PR DESCRIPTION
Reverts spinkube/spin-operator#100

We've explicitly been not pushing mutable tags as they are subject to surprise breakage and changes - especially during fast moving iteration of early development. Installing a copy of the operator shouldn't break because a container restarted.

This is before you get into the general anti-pattern of mutable tags as a distribution mechanism.