### PR TITLE
feat(chart): enable kwasm disable

### DIFF
--- a/charts/spin-operator/Chart.yaml
+++ b/charts/spin-operator/Chart.yaml
@@ -26,4 +26,4 @@ dependencies:
   - name: kwasm-operator
     version: "0.2.3"
     repository: "http://kwasm.sh/kwasm-operator"
-
+    condition: kwasm-operator.enabled


### PR DESCRIPTION
- Enable disabling the kwasm-operator sub-chart

It turns out that the value when not supplied defaults to true, which is convenient for the time being prior to [our using/supplying a curated values file](https://github.com/spinkube/spin-operator/pull/73).  Meaning, the default behavior is that the kwasm-operator will be installed, unless `--set kwasm-operator.enabled=false` is supplied.

Primary use case: When installers of the Spin Operator manage kwasm/shims separately, it would be convenient to disable installing the sub-chart to avoid overriding/replacing the shim inadvertently with a different version, etc.