### PR TITLE
mark readyReplicas as required

### DIFF
--- a/api/v1/spinapp_types.go
+++ b/api/v1/spinapp_types.go
@@ -95,7 +95,7 @@ type SpinAppStatus struct {
 	ActiveScheduler string `json:"activeScheduler,omitempty"`
 
 	// Represents the current number of active replicas on the application deployment.
-	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
+	ReadyReplicas int32 `json:"readyReplicas"`
 }
 
 // SpinApp is the Schema for the spinapps API

--- a/config/crd/bases/core.spinoperator.dev_spinapps.yaml
+++ b/config/crd/bases/core.spinoperator.dev_spinapps.yaml
@@ -2211,6 +2211,8 @@ spec:
                   application deployment.
                 format: int32
                 type: integer
+            required:
+            - readyReplicas
             type: object
         type: object
     served: true


### PR DESCRIPTION
New output:

```
><> k get spinapp
NAME             READY   DESIRED   EXECUTOR
simple-spinapp   0       1         containerd-shim-spin
```

closes #130