### PR TITLE
charts: spinkube -> spinframework for all links

### DIFF
--- a/charts/spin-operator/README.md
+++ b/charts/spin-operator/README.md
@@ -17,8 +17,8 @@ Prior to installing the chart, you'll need to ensure the following:
 - spin-operator CustomResourceDefinition (CRD) resources are installed. This includes the SpinApp CRD representing Spin applications to be scheduled on the cluster.
 
   ```console
-  $ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
-  $ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
+  $ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
+  $ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
   ```
 
 ## Installing the chart
@@ -30,7 +30,7 @@ $ helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
   --version {{ CHART_VERSION }} \
-  oci://ghcr.io/spinkube/charts/spin-operator
+  oci://ghcr.io/spinframework/charts/spin-operator
 ```
 
 ## Post-installation
@@ -40,13 +40,13 @@ spin-operator depends on the following resources. If not already present on the 
 - An application executor is installed. This is the executor that spin-operator uses to run Spin applications.
 
   ```console
-  $ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/spin-shim-executor.yaml
+  $ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/samples/spin-shim-executor.yaml
   ```
 
 - A RuntimeClass resource for the `wasmtime-spin-v2` container runtime is installed. This is the runtime that Spin applications use.
 
   ```console
-  $ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/spin-runtime-class.yaml
+  $ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/samples/spin-runtime-class.yaml
   ```
 
 ## Upgrading the chart
@@ -54,8 +54,8 @@ spin-operator depends on the following resources. If not already present on the 
 Note that you may also need to upgrade the spin-operator CRDs in tandem with upgrading the Helm release:
 
 ```console
-$ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
-$ kubectl apply -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
 ```
 
 To upgrade the `spin-operator` release, run the following:
@@ -64,7 +64,7 @@ To upgrade the `spin-operator` release, run the following:
 $ helm upgrade spin-operator \
   --namespace spin-operator \
   --version {{ CHART_VERSION }} \
-  oci://ghcr.io/spinkube/charts/spin-operator
+  oci://ghcr.io/spinframework/charts/spin-operator
 ```
 
 ## Uninstalling the chart
@@ -80,8 +80,8 @@ This will remove all Kubernetes resources associated with the chart and deletes 
 To completely uninstall all resources related to spin-operator, you may want to delete the corresponding CRD resources and, optionally, the RuntimeClass:
 
 ```console
-$ kubectl delete -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/spin-runtime-class.yaml
-$ kubectl delete -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/samples/spin-shim-executor.yaml
-$ kubectl delete -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
-$ kubectl delete -f https://raw.githubusercontent.com/spinkube/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/samples/spin-runtime-class.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/samples/spin-shim-executor.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinapps.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/spinframework/spin-operator/main/config/crd/bases/core.spinkube.dev_spinappexecutors.yaml
 ```

--- a/charts/spin-operator/templates/NOTES.txt
+++ b/charts/spin-operator/templates/NOTES.txt
@@ -13,14 +13,14 @@ already done so, please ensure the following:
 
 1. Install the containerd-shim-spin SpinAppExecutor:
 
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v{{ .Chart.Version }}/spin-operator.shim-executor.yaml
+  $ kubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v{{ .Chart.Version }}/spin-operator.shim-executor.yaml
 
 2. Install the wasmtime-spin-v2 RuntimeClass:
 
-  $ kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v{{ .Chart.Version }}/spin-operator.runtime-class.yaml
+  $ kubectl apply -f https://github.com/spinframework/spin-operator/releases/download/v{{ .Chart.Version }}/spin-operator.runtime-class.yaml
 
 You are now ready to deploy your first Spin app!
 
 For further details, see this chart's README:
 
-  $ helm show readme oci://ghcr.io/spinkube/charts/spin-operator
+  $ helm show readme oci://ghcr.io/spinframework/charts/spin-operator

--- a/charts/spin-operator/values.yaml
+++ b/charts/spin-operator/values.yaml
@@ -22,7 +22,7 @@ controllerManager:
     ## image indicates which repository and tag combination will be used for
     ## pulling the operator image.
     image:
-      repository: ghcr.io/spinkube/spin-operator
+      repository: ghcr.io/spinframework/spin-operator
       ## By default, .Chart.AppVersion is used as the tag.
       ## Updating this value to a version not aligned with the current chart
       ## version may lead to unexpected or broken behavior.
@@ -30,7 +30,7 @@ controllerManager:
     imagePullPolicy: IfNotPresent
     ## resources represent default cpu/mem limits for the operator container.
     resources:
-      # TODO: update these per https://github.com/spinkube/spin-operator/issues/21
+      # TODO: update these per https://github.com/spinframework/spin-operator/issues/21
       limits:
         cpu: 500m
         memory: 128Mi


### PR DESCRIPTION
This PR changes "spinkube" to "spinframework" in the helm chart's links.

More importantly, it also changes the helm chart's default image repository to "ghcr.io/spinframework".

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
