### PR TITLE
chore/fix(*): s/spinkube/spinframework for ghcr and github org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ First, any contribution and interaction on any SpinKube project MUST follow our 
 Conduct](https://github.com/spinkube/governance/blob/main/CODE_OF_CONDUCT.md). Thank you for being part of an inclusive and open community!
 
 If you plan on contributing anything complex, please go through the [open
-issues](https://github.com/spinkube/spin-operator/issues) and [PR queue](https://github.com/spinkube/spin-operator/pulls)
+issues](https://github.com/spinframework/spin-operator/issues) and [PR queue](https://github.com/spinframework/spin-operator/pulls)
 first to make sure someone else has not started working on it. If it doesn't exist already, please [open an
-issue](https://github.com/spinkube/spin-operator/issues/new) so you have a chance to get feedback from the community and
+issue](https://github.com/spinframework/spin-operator/issues/new) so you have a chance to get feedback from the community and
 the maintainers before you start working on your feature.
 
 ## Making Code Contributions to spin-operator
@@ -32,7 +32,7 @@ can correctly build the project:
 
 ```console
 # clone the repository
-$ git clone https://github.com/spinkube/spin-operator && cd spin-operator
+$ git clone https://github.com/spinframework/spin-operator && cd spin-operator
 # add a new remote pointing to your fork of the project
 $ git remote add fork https://github.com/<your-username>/spin-operator
 # create a new branch for your work
@@ -49,7 +49,7 @@ $ make test
 ```
 
 Now you should be ready to start making your contribution. To familiarize yourself with the spin-operator project,
-please read the [README](https://github.com/spinkube/spin-operator). Since most of spin-operator is written in Go, we try
+please read the [README](https://github.com/spinframework/spin-operator). Since most of spin-operator is written in Go, we try
 to follow the common Go coding conventions. If applicable, add unit or integration tests to ensure your contribution is
 correct.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG_LDFLAGS           := github.com/prometheus/common/version
 LDFLAGS               := -s -w -X ${PKG_LDFLAGS}.Version=${VERSION} -X ${PKG_LDFLAGS}.Revision=${COMMIT} -X ${PKG_LDFLAGS}.BuildDate=${DATE} -X ${PKG_LDFLAGS}.Branch=${BRANCH}
 
 # Image URL to use all building/pushing image targets
-IMG_REPO ?= ghcr.io/spinkube/spin-operator
+IMG_REPO ?= ghcr.io/spinframework/spin-operator
 IMG ?= $(IMG_REPO):$(shell git rev-parse --short HEAD)-dev
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -206,7 +206,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	@echo "==> Kustomizing configuration to use: $(IMG)"
-	@cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/spinkube/spin-operator=${IMG}
+	@cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/spinframework/spin-operator=${IMG}
 	@echo "==> Applying Configuration"
 	@$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 	@echo -e "\n\nSpin Operator has been deployed - you may now want to:\n\n\tkubectl apply -f config/samples/spin-runtime-class.yaml"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,21 +12,21 @@ To push a tag, do the following:
 
 ```console
 git checkout main
-git remote add upstream git@github.com:spinkube/spin-operator
+git remote add upstream git@github.com:spinframework/spin-operator
 git pull upstream main
 git tag --sign $TAG --message "Release $TAG"
 git push upstream $TAG
 ```
 
-Observe that the [CI run for that tag](https://github.com/spinkube/spin-operator/actions) completed.
+Observe that the [CI run for that tag](https://github.com/spinframework/spin-operator/actions) completed.
 
 Bump the Helm chart versions. See #311 for an example.
 
 Next, you'll need to update the documentation:
 
 ```console
-git clone git@github.com:spinkube/documentation
-cd documentation
+git clone git@github.com:spinframework/spinkube-docs
+cd spinkube-docs
 ```
 
 Change all references from the previous version to the new version.

--- a/config/chart/values.yaml
+++ b/config/chart/values.yaml
@@ -22,7 +22,7 @@ controllerManager:
     ## image indicates which repository and tag combination will be used for
     ## pulling the operator image.
     image:
-      repository: ghcr.io/spinkube/spin-operator
+      repository: ghcr.io/spinframework/spin-operator
       ## By default, .Chart.AppVersion is used as the tag.
       ## Updating this value to a version not aligned with the current chart
       ## version may lead to unexpected or broken behavior.
@@ -30,7 +30,7 @@ controllerManager:
     imagePullPolicy: IfNotPresent
     ## resources represent default cpu/mem limits for the operator container.
     resources:
-      # TODO: update these per https://github.com/spinkube/spin-operator/issues/21
+      # TODO: update these per https://github.com/spinframework/spin-operator/issues/21
       limits:
         cpu: 500m
         memory: 128Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,7 +65,7 @@ spec:
           args:
             - --leader-elect
             - --enable-webhooks
-          image: ghcr.io/spinkube/spin-operator:latest
+          image: ghcr.io/spinframework/spin-operator:latest
           name: manager
           imagePullPolicy: IfNotPresent
           securityContext:

--- a/config/samples/hpa.yaml
+++ b/config/samples/hpa.yaml
@@ -3,7 +3,7 @@ kind: SpinApp
 metadata:
   name: hpa-spinapp
 spec:
-  image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
+  image: ghcr.io/spinframework/spin-operator/cpu-load-gen:20250625-200717-g19414c1
   executor: containerd-shim-spin
   enableAutoscaling: true
   resources:

--- a/config/samples/keda-app.yaml
+++ b/config/samples/keda-app.yaml
@@ -3,7 +3,7 @@ kind: SpinApp
 metadata:
   name: keda-spinapp
 spec:
-  image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
+  image: ghcr.io/spinframework/spin-operator/cpu-load-gen:20250625-200717-g19414c1
   executor: containerd-shim-spin
   enableAutoscaling: true
   resources:

--- a/config/samples/otel.yaml
+++ b/config/samples/otel.yaml
@@ -3,7 +3,7 @@ kind: SpinApp
 metadata:
   name: otel-spinapp
 spec:
-  image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
+  image: ghcr.io/spinframework/spin-operator/cpu-load-gen:20250625-200717-g19414c1
   executor: otel-shim-executor
   replicas: 1
 ---

--- a/config/samples/redis.yaml
+++ b/config/samples/redis.yaml
@@ -3,7 +3,7 @@ kind: SpinApp
 metadata:
   name: redis-spinapp
 spec:
-  image: "ghcr.io/spinkube/spin-operator/redis-sample:20240820-095510-g8d6b442"
+  image: "ghcr.io/spinframework/spin-operator/redis-sample:20250625-200716-g19414c1"
   replicas: 1
   executor: containerd-shim-spin
-# Steps to run this found at https://github.com/spinkube/spin-operator/pull/131
+# Steps to run this found at https://github.com/spinframework/spin-operator/pull/131

--- a/config/samples/selective-deployment.yaml
+++ b/config/samples/selective-deployment.yaml
@@ -3,7 +3,7 @@ kind: SpinApp
 metadata:
   name: hello-salutation-spinapp
 spec:
-  image: "ghcr.io/spinkube/spin-operator/salutations:20241105-223428-g4da3171"
+  image: "ghcr.io/spinframework/spin-operator/salutations:20250625-200719-g19414c1"
   replicas: 1
   executor: containerd-shim-spin
   # Configure the application to only contain the "hello" component

--- a/config/samples/spintainer.yaml
+++ b/config/samples/spintainer.yaml
@@ -3,6 +3,6 @@ kind: SpinApp
 metadata:
   name: spintainer-spinapp
 spec:
-  image: "ghcr.io/spinkube/spin-operator/hello-world:20240708-130250-gfefd2b1"
+  image: "ghcr.io/spinframework/spin-operator/hello-world:20250625-200716-g19414c1"
   replicas: 1
   executor: spintainer

--- a/e2e/selective_deployment_test.go
+++ b/e2e/selective_deployment_test.go
@@ -23,7 +23,7 @@ import (
 func TestSelectiveDeployment(t *testing.T) {
 	var client klient.Client
 
-	appImage := "ghcr.io/spinkube/spin-operator/salutations:20241105-223428-g4da3171"
+	appImage := "ghcr.io/spinframework/spin-operator/salutations:20250625-200719-g19414c1"
 	testSpinAppName := "test-component-filtering"
 
 	defaultTest := features.New("default and most minimal setup").
@@ -81,7 +81,7 @@ func TestSelectiveDeployment(t *testing.T) {
 func TestSelectiveDeploymentSpintainer(t *testing.T) {
 	var client klient.Client
 
-	salutationsApp := "ghcr.io/spinkube/spin-operator/salutations:20241105-223428-g4da3171"
+	salutationsApp := "ghcr.io/spinframework/spin-operator/salutations:20250625-200719-g19414c1"
 	testSpinAppName := "test-spintainer-selective-deployment"
 
 	defaultTest := features.New("default and most minimal setup").

--- a/e2e/spintainer_test.go
+++ b/e2e/spintainer_test.go
@@ -23,7 +23,7 @@ import (
 func TestSpintainer(t *testing.T) {
 	var client klient.Client
 
-	helloWorldImage := "ghcr.io/spinkube/spin-operator/hello-world:20240708-130250-gfefd2b1"
+	helloWorldImage := "ghcr.io/spinframework/spin-operator/hello-world:20250625-200716-g19414c1"
 	testSpinAppName := "test-spintainer-app"
 
 	defaultTest := features.New("default and most minimal setup").

--- a/scripts/update-chart-versions.sh
+++ b/scripts/update-chart-versions.sh
@@ -5,8 +5,8 @@ set -eou pipefail
 
 # Swap tag in for main for URLs if the version is vx.x.x*
 if [[ "${APP_VERSION}" =~ ^v[0-9]+.[0-9]+.[0-9]+(.*)? ]]; then
-  sed -i.bak -e "s%spinkube/spin-operator/main%spinkube/spin-operator/${APP_VERSION}%g" "${STAGING_DIR}/${CHART_NAME}-${CHART_VERSION}/README.md"
-  sed -i.bak -e "s%spinkube/spin-operator/main%spinkube/spin-operator/${APP_VERSION}%g" "${STAGING_DIR}/${CHART_NAME}-${CHART_VERSION}/templates/NOTES.txt"
+  sed -i.bak -e "s%spinframework/spin-operator/main%spinframework/spin-operator/${APP_VERSION}%g" "${STAGING_DIR}/${CHART_NAME}-${CHART_VERSION}/README.md"
+  sed -i.bak -e "s%spinframework/spin-operator/main%spinframework/spin-operator/${APP_VERSION}%g" "${STAGING_DIR}/${CHART_NAME}-${CHART_VERSION}/templates/NOTES.txt"
 fi
 
 ## Update Chart.yaml with CHART_VERSION and APP_VERSION


### PR DESCRIPTION
Ref https://github.com/spinframework/spin-operator/issues/408

Updates the ghcr/github org from `spinkube` to `spinframework`.

We'll probably want to cut a 0.6.1 release with these changes, to fix the behavior mentioned in https://github.com/spinframework/spin-operator/issues/408.

_(Note: I see we had intended to update the operator image in the chart's values.yaml in https://github.com/spinframework/spin-operator/pull/382, but alas the value needs to be updated under `config/chart/values.yaml` for it to take effect, as the chart is regenerated via `helmify` when packaging up on a release.)_

TODO:
- [ ] ~~update go pkg/project urls?~~ I created [a separate follow-up](https://github.com/spinframework/spin-operator/issues/410) as there is urgency to get a new release/Helm chart cut as the default 0.6.0 chart is broken