### PR TITLE
chore(apps): update build commands

### DIFF
--- a/apps/cpu-load-gen/spin.toml
+++ b/apps/cpu-load-gen/spin.toml
@@ -14,5 +14,5 @@ component = "cpu-load-gen"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.cpu-load-gen.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]

--- a/apps/hello-world/spin.toml
+++ b/apps/hello-world/spin.toml
@@ -14,5 +14,5 @@ component = "hello-world"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.hello-world.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]

--- a/apps/order-processor/spin.toml
+++ b/apps/order-processor/spin.toml
@@ -17,4 +17,4 @@ component = "order-processor"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.order-processor.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"

--- a/apps/outbound-http/spin.toml
+++ b/apps/outbound-http/spin.toml
@@ -14,4 +14,4 @@ component = "hello"
 source = "main.wasm"
 allowed_outbound_hosts = ["https://random-data-api.fermyon.app:443"]
 [component.hello.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"

--- a/apps/redis-sample/spin.toml
+++ b/apps/redis-sample/spin.toml
@@ -17,7 +17,7 @@ source = "main.wasm"
 allowed_outbound_hosts = ["redis://*"]
 
 [component.spin-redis-sample.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]
 
 [component.spin-redis-sample.variables]

--- a/apps/salutations/spin.toml
+++ b/apps/salutations/spin.toml
@@ -14,7 +14,7 @@ component = "hello"
 source = "../hello-world/main.wasm"
 allowed_outbound_hosts = []
 [component.hello.build]
-command = "cd ../hello-world && tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "cd ../hello-world && tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]
 
 [[trigger.http]]
@@ -25,5 +25,5 @@ component = "goodbye"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.goodbye.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]

--- a/apps/variable-explorer/spin.toml
+++ b/apps/variable-explorer/spin.toml
@@ -16,7 +16,7 @@ route = "/..."
 component = "variable-explorer"
 
 [component.variable-explorer]
-source = "target/wasm32-wasi/release/variable_explorer.wasm"
+source = "target/wasm32-wasip1/release/variable_explorer.wasm"
 allowed_outbound_hosts = []
 
 [component.variable-explorer.variables]
@@ -25,5 +25,5 @@ platform_name = "{{ platform_name }}"
 db_password = "{{ db_password }}"
 
 [component.variable-explorer.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/apps/variabletester/Dockerfile
+++ b/apps/variabletester/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 
 COPY . .
 
-RUN tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go
+RUN tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go
 
 FROM scratch
 COPY --from=build /opt/build/main.wasm .

--- a/apps/variabletester/spin.toml
+++ b/apps/variabletester/spin.toml
@@ -21,5 +21,5 @@ allowed_outbound_hosts = []
 greetee = "{{ greetee }}"
 
 [component.variabletester.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm main.go"
 watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
Went to build and run one of these apps the other day and noticed some updates were in order.

The updated tinygo commands were sourced from current examples in the spin-go-sdk repo, eg https://github.com/spinframework/spin-go-sdk/blob/main/examples/http/spin.toml#L16